### PR TITLE
Fix: prevent pets from showing before searching

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -6,7 +6,11 @@ class ApplicationsController < ApplicationController
 
   def show
     @application = Application.find(params[:id])
-    @pets_found = Pet.adoptable.search_for(params[:search])
+    if params.include?(:search)
+      @pets_found = Pet.adoptable.search_for(params[:search])
+    else
+      @pets_found = []
+    end
   end
 
   def new


### PR DESCRIPTION
One last bit of logic to prevent pets for displaying before a search has been done.